### PR TITLE
Use passed pixelblazeIp when getting client

### DIFF
--- a/core/src/main/kotlin/industries/hannah/pixelblaze/Pixelblaze.kt
+++ b/core/src/main/kotlin/industries/hannah/pixelblaze/Pixelblaze.kt
@@ -267,7 +267,7 @@ interface Pixelblaze : Closeable {
         /**
          * Get a default client, specifying only the IP
          */
-        fun default(pixelblazeIp: String): Pixelblaze = WebsocketPixelblaze.defaultBuilder().build()
+        fun default(pixelblazeIp: String): Pixelblaze = WebsocketPixelblaze.defaultBuilder().setPixelblazeIp(pixelblazeIp).build()
 
         /**
          * Utility method to take a camelCase variable name and return "Camel Case". If it starts with "slider"


### PR DESCRIPTION
Currently the passed IP address is ignored, this PR fixes this.